### PR TITLE
Add --enable-stackdriver-kubernetes option

### DIFF
--- a/istio-stackdriver/README.md
+++ b/istio-stackdriver/README.md
@@ -41,6 +41,7 @@ gcloud services enable container.googleapis.com
 ```
 gcloud beta container clusters create istio-stackdriver-demo \
     --addons=Istio --istio-config=auth=MTLS_PERMISSIVE \
+    --enable-stackdriver-kubernetes \
     --zone=us-central1-f \
     --machine-type=n1-standard-2 \
     --num-nodes=4


### PR DESCRIPTION
Following this tutorial, Memory Usage (kubernetes.io/node/memory/used_bytes) chart can't be added. Enabling Stackdriver Kubernetes Monitoring resolved this issue.