### PR TITLE
Avoid error when using numeric ip with hosts.

### DIFF
--- a/security-intro/hipstershop/istio-manifests.yaml
+++ b/security-intro/hipstershop/istio-manifests.yaml
@@ -120,12 +120,13 @@ metadata:
   name: whitelist-egress-googleapis
 spec:
   hosts:
-  - "169.254.169.254" # GCE metadata server
   - "metadata.google" # GCE metadata server
   - "metadata.google.internal" # GCE metadata server
   - "accounts.google.com" # Used to get token
   - "*.googleapis.com"
   - "*.githubusercontent.com" # used to demo Istio's Origin auth feature / test JWT 
+  addresses:
+  - "169.254.169.254" # GCE metadata server
   ports:
   - number: 80
     protocol: HTTP


### PR DESCRIPTION
This should fix a minor error I see running this as a lab I ported.
To be clear, I ported this to a Qwiklabs lab.