### PR TITLE
Sync with upstream microservices-demo.

### DIFF
--- a/security-intro/hipstershop/istio-manifests.yaml
+++ b/security-intro/hipstershop/istio-manifests.yaml
@@ -120,11 +120,7 @@ metadata:
   name: whitelist-egress-googleapis
 spec:
   hosts:
-  - "metadata.google" # GCE metadata server
   - "metadata.google.internal" # GCE metadata server
-  - "accounts.google.com" # Used to get token
-  - "*.googleapis.com"
-  - "*.githubusercontent.com" # used to demo Istio's Origin auth feature / test JWT 
   addresses:
   - "169.254.169.254" # GCE metadata server
   ports:


### PR DESCRIPTION
This shows as a problem intermittently. Adjusting this to match the version in microservices-demo seems to always fix, when the problem is observed.
The problem manifests as an ugly error page from currency service unable to do its job. 