### PR TITLE
Move GCE metadata server address to addresses ServiceEntry section

### DIFF
--- a/istio-canary-gke/hipstershop/istio-manifests.yaml
+++ b/istio-canary-gke/hipstershop/istio-manifests.yaml
@@ -120,11 +120,12 @@ metadata:
   name: whitelist-egress-googleapis
 spec:
   hosts:
-  - "169.254.169.254" # GCE metadata server
   - "metadata.google" # GCE metadata server
   - "metadata.google.internal" # GCE metadata server
   - "accounts.google.com" # Used to get token
   - "*.googleapis.com"
+  addresses:
+  - "169.254.169.254" # GCE metadata server
   ports:
   - number: 80
     protocol: HTTP
@@ -133,3 +134,4 @@ spec:
     protocol: HTTPS
     name: https
 ---
+

--- a/istio-canary-gke/hipstershop/kubernetes-manifests.yaml
+++ b/istio-canary-gke/hipstershop/kubernetes-manifests.yaml
@@ -552,7 +552,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.1.2
+        image: gcr.io/google-samples/microservices-demo/currencyservice:31df60f
         ports:
         - name: grpc
           containerPort: 7000

--- a/istio-canary-gke/hipstershop/kubernetes-manifests.yaml
+++ b/istio-canary-gke/hipstershop/kubernetes-manifests.yaml
@@ -552,7 +552,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/currencyservice:31df60f
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.1.2
         ports:
         - name: grpc
           containerPort: 7000


### PR DESCRIPTION
Fixes `Error from server: error when creating "istio-manifests.yaml": admission webhook "pilot.validation.istio.io" denied the request: configuration is invalid: domain name "254.169.254" invalid (top level domain "254" cannot be all-numeric)`
 error