### PR TITLE
Bump Istio version to 1.4.2 on multicluster-gke dual-control-plane

### DIFF
--- a/multicluster-gke/dual-control-plane/README.md
+++ b/multicluster-gke/dual-control-plane/README.md
@@ -12,7 +12,7 @@ different [virtual networks](https://cloud.google.com/kubernetes-engine/docs/con
 
 ## How it works
 
-This demo uses Istio 1.1's [Gateway-Connected Clusters](https://preliminary.istio.io/docs/concepts/multicluster-deployments/#multiple-control-plane-topology) feature. This is a specific mode of
+This demo uses Istio 1.4's [Gateway-Connected Clusters](https://preliminary.istio.io/docs/concepts/multicluster-deployments/#multiple-control-plane-topology) feature. This is a specific mode of
 multicluster Istio where two separate Kubernetes clusters run their own Istio control
 plane, and orchestrate their own mesh. But each Istio control plane also runs a CoreDNS
 server, which allows services in both clusters to refer to services in the other cluster,

--- a/multicluster-gke/dual-control-plane/cluster1/service-entries.yaml
+++ b/multicluster-gke/dual-control-plane/cluster1/service-entries.yaml
@@ -20,7 +20,7 @@ metadata:
   name: frontendservice-entry
 spec:
   addresses:
-  - 127.255.0.5
+  - 240.0.0.5
   endpoints:
   - address: 35.222.46.19
     ports:
@@ -42,7 +42,7 @@ metadata:
   name: productcatalogservice-entry
 spec:
   addresses:
-  - 127.255.0.6
+  - 240.0.0.6
   endpoints:
   - address: 35.222.46.19
     ports:
@@ -64,7 +64,7 @@ metadata:
   name: cartservice-entry
 spec:
   addresses:
-  - 127.255.0.7
+  - 240.0.0.7
   endpoints:
   - address: 35.222.46.19
     ports:

--- a/multicluster-gke/dual-control-plane/cluster2/service-entries.yaml
+++ b/multicluster-gke/dual-control-plane/cluster2/service-entries.yaml
@@ -20,7 +20,7 @@ metadata:
   name: adservice-entry
 spec:
   addresses:
-  - 127.255.0.2
+  - 240.0.0.2
   endpoints:
   - address: 34.67.127.28
     ports:
@@ -42,7 +42,7 @@ metadata:
   name: checkoutservice-entry
 spec:
   addresses:
-  - 127.255.0.3
+  - 240.0.0.3
   endpoints:
   - address: 34.67.127.28
     ports:
@@ -64,7 +64,7 @@ metadata:
   name: currencyservice-entry
 spec:
   addresses:
-  - 127.255.0.4
+  - 240.0.0.4
   endpoints:
   - address: 34.67.127.28
     ports:
@@ -86,7 +86,7 @@ metadata:
   name: shippingservice-entry
 spec:
   addresses:
-  - 127.255.0.8
+  - 240.0.0.8
   endpoints:
   - address: 34.67.127.28
     ports:

--- a/multicluster-gke/dual-control-plane/scripts/2-istio-preinstall.sh
+++ b/multicluster-gke/dual-control-plane/scripts/2-istio-preinstall.sh
@@ -32,7 +32,7 @@ preinstall_istio () {
 
 # set vars
 ZONE="us-central1-b"
-ISTIO_VERSION=${ISTIO_VERSION:=1.2.2}
+ISTIO_VERSION=${ISTIO_VERSION:=1.4.2}
 
 PROJECT_1="${PROJECT_1:?PROJECT_1 env variable must be specified}"
 CLUSTER_1="dual-cluster1"

--- a/multicluster-gke/dual-control-plane/scripts/3-istio-install.sh
+++ b/multicluster-gke/dual-control-plane/scripts/3-istio-install.sh
@@ -24,7 +24,7 @@ install_istio () {
 
 # set vars
 ZONE="us-central1-b"
-ISTIO_VERSION=${ISTIO_VERSION:=1.2.2}
+ISTIO_VERSION=${ISTIO_VERSION:=1.4.2}
 
 PROJECT_1="${PROJECT_1:?PROJECT_1 env variable must be specified}"
 CLUSTER_1="dual-cluster1"


### PR DESCRIPTION
Change ServiceEntry addresses from Class A to Class E to allow multi-cluster
communication on dual control plane.
See https://github.com/istio/istio/issues/16890.