### PR TITLE
fix race condition

### DIFF
--- a/multicluster-gke/single-control-plane/scripts/1-cluster-create.sh
+++ b/multicluster-gke/single-control-plane/scripts/1-cluster-create.sh
@@ -28,6 +28,8 @@ log "Creating cluster1..."
 "https://www.googleapis.com/auth/trace.append" \
 --num-nodes "2" --network "default" --enable-cloud-logging --enable-cloud-monitoring --enable-ip-alias --async
 
+sleep 20
+
 log "Creating cluster2..."
   gcloud container clusters create cluster-2 --zone $cluster2zone --username "admin" \
   --machine-type "n1-standard-4" --image-type "COS" --disk-size "100" \


### PR DESCRIPTION
Inject a delay between cluster1 creation and cluster 2 creation.

Currently, some significant percentrage of the time, cluster2 tries to grab the sam CIDR block of IPs as cluster1 - and this cause a failure in creating cluster2.

Introducing the delay avoids this problem.