### PR TITLE
Replaced deprecated flags

### DIFF
--- a/mesh-expansion-gce/scripts/1-create-cluster.sh
+++ b/mesh-expansion-gce/scripts/1-create-cluster.sh
@@ -28,4 +28,4 @@ gcloud config set project $PROJECT_ID
 
  gcloud container clusters create $CLUSTER_NAME --zone $ZONE --username "admin" \
   --machine-type "n1-standard-2" --image-type "COS" --disk-size "100" \
---num-nodes "4" --network "default" --enable-cloud-logging --enable-cloud-monitoring --enable-ip-alias --async
+--num-nodes "4" --network "default" --enable-stackdriver-kubernetes --enable-ip-alias --async

--- a/multicluster-gke/dual-control-plane/scripts/1-create-gke-clusters.sh
+++ b/multicluster-gke/dual-control-plane/scripts/1-create-gke-clusters.sh
@@ -26,7 +26,7 @@ gcloud container clusters create $CLUSTER_1 --zone $ZONE --username "admin" \
 "https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
 "https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\
 "https://www.googleapis.com/auth/trace.append" \
---num-nodes "4" --network "default" --enable-cloud-logging --enable-cloud-monitoring  --async
+--num-nodes "4" --network "default" --enable-stackdriver-kubernetes  --async
 
 
 # Project 2 - Create GKE Cluster 2
@@ -34,4 +34,4 @@ gcloud config set project $PROJECT_2
 
 gcloud container clusters create $CLUSTER_2 --zone $ZONE --username "admin" \
 --machine-type "n1-standard-2" --image-type "COS" --disk-size "100" \
---num-nodes "4" --network "default" --enable-cloud-logging --enable-cloud-monitoring --async
+--num-nodes "4" --network "default" --enable-stackdriver-kubernetes --async

--- a/multicluster-gke/single-control-plane/scripts/1-cluster-create.sh
+++ b/multicluster-gke/single-control-plane/scripts/1-cluster-create.sh
@@ -26,7 +26,7 @@ log "Creating cluster1..."
 "https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
 "https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\
 "https://www.googleapis.com/auth/trace.append" \
---num-nodes "2" --network "default" --enable-cloud-logging --enable-cloud-monitoring --enable-ip-alias --async
+--num-nodes "2" --network "default" --enable-stackdriver-kubernetes --enable-ip-alias --async
 
 sleep 20
 
@@ -37,4 +37,4 @@ log "Creating cluster2..."
 "https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
 "https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\
 "https://www.googleapis.com/auth/trace.append" \
---num-nodes "2" --network "default" --enable-cloud-logging --enable-cloud-monitoring --enable-ip-alias --async
+--num-nodes "2" --network "default" --enable-stackdriver-kubernetes --enable-ip-alias --async

--- a/multicluster-gke/vm-migration/scripts/1-create-infra.sh
+++ b/multicluster-gke/vm-migration/scripts/1-create-infra.sh
@@ -26,7 +26,7 @@ gcloud container clusters create ${CLUSTER_1_NAME} --zone ${CLUSTER_1_ZONE} --us
 "https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
 "https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\
 "https://www.googleapis.com/auth/trace.append" \
---num-nodes "4" --network "default" --enable-cloud-logging --enable-cloud-monitoring  --async
+--num-nodes "4" --network "default" --enable-stackdriver-kubernetes  --async
 
 gcloud container clusters create ${CLUSTER_2_NAME} --zone ${CLUSTER_2_ZONE} --username "admin" \
 --machine-type "n1-standard-4" --image-type "COS" --disk-size "100" \
@@ -34,7 +34,7 @@ gcloud container clusters create ${CLUSTER_2_NAME} --zone ${CLUSTER_2_ZONE} --us
 "https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
 "https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\
 "https://www.googleapis.com/auth/trace.append" \
---num-nodes "4" --network "default" --enable-cloud-logging --enable-cloud-monitoring  --async
+--num-nodes "4" --network "default" --enable-stackdriver-kubernetes  --async
 
 
 # Create 1 VM


### PR DESCRIPTION
I ran into this when qwiklabs was using `multicluster-gke/single-control-plane/scripts/1-cluster-create.sh` to setup a lab and it failed.
Running it in Cloud Shell revealed the `--enable-cloud-logging` and `--enable-cloud-monitoring` flags have been deprecated to now produce an error.

Making the [substitution it recommends](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create#--enable-cloud-logging) resolved the issue and I have duplicated the change to all `gcloud container clusters create` calls.