### PR TITLE
Do not explicitly specify COS where not needed

### DIFF
--- a/multicluster-gke/dual-control-plane/scripts/1-create-gke-clusters.sh
+++ b/multicluster-gke/dual-control-plane/scripts/1-create-gke-clusters.sh
@@ -21,7 +21,6 @@ source ./scripts/env.sh
 gcloud config set project $PROJECT_1
 
 gcloud container clusters create $CLUSTER_1 --zone $ZONE --username "admin" \
---machine-type "n1-standard-2" --image-type "COS" --disk-size "100" \
 --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_only",\
 "https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
 "https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\
@@ -33,5 +32,4 @@ gcloud container clusters create $CLUSTER_1 --zone $ZONE --username "admin" \
 gcloud config set project $PROJECT_2
 
 gcloud container clusters create $CLUSTER_2 --zone $ZONE --username "admin" \
---machine-type "n1-standard-2" --image-type "COS" --disk-size "100" \
 --num-nodes "4" --network "default" --enable-stackdriver-kubernetes --async


### PR DESCRIPTION
Starting with [GKE node version 1.19](https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#:~:text=starting%20with%20gke%20node%20version%201.19), COS image type is deprecated. I suggest to not explicitly specify any parameters where defaults would work.