### PR TITLE
Do not explicitly specify COS where not needed

### DIFF
--- a/multicluster-gke/single-control-plane/scripts/1-cluster-create.sh
+++ b/multicluster-gke/single-control-plane/scripts/1-cluster-create.sh
@@ -21,7 +21,6 @@ source ./scripts/env.sh
 
 log "Creating cluster1..."
  gcloud container clusters create cluster-1 --zone $cluster1zone --username "admin" \
-  --machine-type "n1-standard-4" --image-type "COS" --disk-size "100" \
   --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_only",\
 "https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
 "https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\
@@ -32,7 +31,6 @@ sleep 20
 
 log "Creating cluster2..."
   gcloud container clusters create cluster-2 --zone $cluster2zone --username "admin" \
-  --machine-type "n1-standard-4" --image-type "COS" --disk-size "100" \
   --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_only",\
 "https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
 "https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\


### PR DESCRIPTION
Starting with [GKE node version 1.19](https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#:~:text=starting%20with%20gke%20node%20version%201.19), COS image type is deprecated. I suggest to not explicitly specify any parameters where defaults would work.