### PR TITLE
Do not explicitly specify COS where not needed

### DIFF
--- a/multicluster-gke/vm-migration/scripts/1-create-infra.sh
+++ b/multicluster-gke/vm-migration/scripts/1-create-infra.sh
@@ -21,6 +21,7 @@ log "🚀 Creating clusters..."
 gcloud config set project $PROJECT_ID
 
 gcloud container clusters create ${CLUSTER_1_NAME} --zone ${CLUSTER_1_ZONE} --username "admin" \
+--machine-type "n1-standard-4" \
 --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_only",\
 "https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
 "https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\
@@ -28,6 +29,7 @@ gcloud container clusters create ${CLUSTER_1_NAME} --zone ${CLUSTER_1_ZONE} --us
 --num-nodes "4" --network "default" --enable-stackdriver-kubernetes  --async
 
 gcloud container clusters create ${CLUSTER_2_NAME} --zone ${CLUSTER_2_ZONE} --username "admin" \
+--machine-type "n1-standard-4" \
 --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_only",\
 "https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
 "https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\

--- a/multicluster-gke/vm-migration/scripts/1-create-infra.sh
+++ b/multicluster-gke/vm-migration/scripts/1-create-infra.sh
@@ -21,7 +21,6 @@ log "🚀 Creating clusters..."
 gcloud config set project $PROJECT_ID
 
 gcloud container clusters create ${CLUSTER_1_NAME} --zone ${CLUSTER_1_ZONE} --username "admin" \
---machine-type "n1-standard-4" --image-type "COS" --disk-size "100" \
 --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_only",\
 "https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
 "https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\
@@ -29,7 +28,6 @@ gcloud container clusters create ${CLUSTER_1_NAME} --zone ${CLUSTER_1_ZONE} --us
 --num-nodes "4" --network "default" --enable-stackdriver-kubernetes  --async
 
 gcloud container clusters create ${CLUSTER_2_NAME} --zone ${CLUSTER_2_ZONE} --username "admin" \
---machine-type "n1-standard-4" --image-type "COS" --disk-size "100" \
 --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_only",\
 "https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
 "https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\


### PR DESCRIPTION
Starting with [GKE node version 1.19](https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#:~:text=starting%20with%20gke%20node%20version%201.19), COS image type is deprecated. I suggest to not explicitly specify any parameters where defaults would work.


Also please check whether ubuntu image needs to be updated on this page. Looks old