### PR TITLE
Do not explicitly specify COS where not needed

### DIFF
--- a/mesh-expansion-gce/scripts/1-create-cluster.sh
+++ b/mesh-expansion-gce/scripts/1-create-cluster.sh
@@ -27,5 +27,4 @@ CTX="gke_${PROJECT_ID}_${ZONE}_${CLUSTER_NAME}"
 gcloud config set project $PROJECT_ID
 
  gcloud container clusters create $CLUSTER_NAME --zone $ZONE --username "admin" \
-  --machine-type "n1-standard-2" --image-type "COS" --disk-size "100" \
---num-nodes "4" --network "default" --enable-stackdriver-kubernetes --enable-ip-alias --async
+   --num-nodes "4" --network "default" --enable-stackdriver-kubernetes --enable-ip-alias --async

--- a/mesh-expansion-gce/scripts/1-create-cluster.sh
+++ b/mesh-expansion-gce/scripts/1-create-cluster.sh
@@ -27,4 +27,5 @@ CTX="gke_${PROJECT_ID}_${ZONE}_${CLUSTER_NAME}"
 gcloud config set project $PROJECT_ID
 
  gcloud container clusters create $CLUSTER_NAME --zone $ZONE --username "admin" \
+   --machine-type "n1-standard-2" \
    --num-nodes "4" --network "default" --enable-stackdriver-kubernetes --enable-ip-alias --async


### PR DESCRIPTION
Starting with [GKE node version 1.19](https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#:~:text=starting%20with%20gke%20node%20version%201.19), COS image type is deprecated. I suggest to not explicitly specify any parameters where defaults would work.