### PR TITLE
Do not explicitly specify COS where not needed

### DIFF
--- a/multicluster-ingress/1-create-clusters.sh
+++ b/multicluster-ingress/1-create-clusters.sh
@@ -27,7 +27,7 @@ for svc in "${CLUSTERS[@]}" ; do
     NAME="${svc%%:*}"
     ZONE="${svc##*:}"
     gcloud beta container --project ${PROJECT_ID} clusters create ${NAME} --zone ${ZONE} \
-    --no-enable-basic-auth --release-channel "regular" --machine-type "n1-standard-4" --image-type "COS" \
+    --no-enable-basic-auth --release-channel "regular" --machine-type "n1-standard-4" \
     --disk-type "pd-standard" --disk-size "100" \
     --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
     --num-nodes "3" --enable-stackdriver-kubernetes --enable-ip-alias \


### PR DESCRIPTION
Starting with [GKE node version 1.19](https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#:~:text=starting%20with%20gke%20node%20version%201.19), COS image type is deprecated. I suggest to not explicitly specify any parameters where defaults would work.