### PR TITLE
Do not explicitly specify COS where not needed

### DIFF
--- a/internal-load-balancer/README.md
+++ b/internal-load-balancer/README.md
@@ -35,7 +35,7 @@ PROJECT_ID=<your-project-id>
 
 ```
 gcloud container clusters create istio-ilb --project $PROJECT_ID --zone us-central1-c \
---machine-type "n1-standard-2" --image-type "COS" --disk-size "100" \
+--machine-type "n1-standard-2" --disk-size "100" \
 --num-nodes "4" --network "default" --async
 ```
 


### PR DESCRIPTION
Starting with [GKE node version 1.19](https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#:~:text=starting%20with%20gke%20node%20version%201.19), COS image type is deprecated. I suggest to not explicitly specify any parameters where defaults would work.